### PR TITLE
removed reference to attribute

### DIFF
--- a/src/Core/NodeValidator.php
+++ b/src/Core/NodeValidator.php
@@ -209,7 +209,7 @@ class NodeValidator
             foreach ($uniqueFieldSet as $field) {
                 $attrib = $this->m_nodeObj->m_attribList[$field];
                 if ($attrib) {
-                    $attribs[] = &$attrib;
+                    $attribs[] = $attrib;
 
                     if (is_a($attrib, 'ManyToOneRelation') && count($attrib->m_refKey) > 1) {
                         $attrib->createDestination();


### PR DESCRIPTION
Before this each element of the array attribs would have pointed to last attribute of the field set. 
The error message for the fieldset 
`['field_1', 'field_2'] `
would have been
`Field 2, Field 2: The values for the combination of these fields must be unique `