### PR TITLE
Consistency in the node cache lookup

### DIFF
--- a/src/Core/Atk.php
+++ b/src/Core/Atk.php
@@ -141,6 +141,7 @@ class Atk
             $tabs = [];
         }
 
+        $nodeUri = strtolower($nodeUri);
         $module = Tools::getNodeModule($nodeUri);
         $type = Tools::getNodeType($nodeUri);
         $this->g_nodesClasses[$nodeUri] = $class;


### PR DESCRIPTION
atkRegisterNode should register the nodes in lowercase because atkgetNode searchs in the global cache array with a lower case key.