### PR TITLE
Case sensitivity

### DIFF
--- a/src/Relations/Relation.php
+++ b/src/Relations/Relation.php
@@ -53,7 +53,7 @@ class Relation extends Attribute
     public function __construct($name, $flags = 0, $destination)
     {
         parent::__construct($name, $flags);
-        $this->m_destination = strtolower($destination);
+        $this->m_destination = $destination;
     }
 
     /**


### PR DESCRIPTION
In order to make relations case sensisitive as the other parts of the framework are migrating to it.