### PR TITLE
Fixing setIndex functionnality

### DIFF
--- a/src/DataGrid/DataGrid.php
+++ b/src/DataGrid/DataGrid.php
@@ -478,7 +478,7 @@ class DataGrid
         $this->addComponent('paginator', __NAMESPACE__.'\\DataGridPaginator');
 
         if (!empty($this->getNode()->m_index)) {
-            $this->addComponent('index', 'atk.datagrid.atkdgindex');
+            $this->addComponent('index', __NAMESPACE__.'\\DataGridIndex');
         }
 
         if (count($this->getNode()->m_editableListAttributes) > 0) {


### PR DESCRIPTION
Hello

I guess Node->setIndex stopped to work in 9.0 due to incomplete migration (see surrounding lines in DataGrid.php).

I've tested this fix only for one project, I can't ensure it will work very well. But it seems quite an obvious fix.