### PR TITLE
Fix section icons

### DIFF
--- a/src/Handlers/ViewEditBase.php
+++ b/src/Handlers/ViewEditBase.php
@@ -6,6 +6,7 @@ use Sintattica\Atk\Session\SessionManager;
 use Sintattica\Atk\Core\Tools;
 use Sintattica\Atk\Session\State;
 use Sintattica\Atk\Core\Node;
+use Sintattica\Atk\Core\Config;
 use Sintattica\Atk\Session\SessionStore;
 
 /**
@@ -145,20 +146,20 @@ class ViewEditBase extends ActionHandler
 
         // create onclick statement.
         $onClick = " onClick=\"javascript:handleSectionToggle(this,null,'{$url}'); return false;\"";
-        $initClass = 'openedSection';
+        $initIcon = 'icon_minussquare';
 
         //if the section is not active, we close it on load.
         $default = in_array($field['name'], $this->m_node->getActiveSections($tab, $mode)) ? 'opened' : 'closed';
         $sectionstate = State::get(array('nodetype' => $this->m_node->atkNodeUri(), 'section' => $name), $default);
 
         if ($sectionstate == 'closed') {
-            $initClass = 'closedSection';
+            $initIcon = 'icon_plussquare';
             $page = $this->getPage();
             $page->register_scriptcode("addClosedSection('$name');");
         }
 
         // create the clickable link
-        return '<span class="atksectionwr"><a href="javascript:void(0)" id="'.$name.'" class="atksection '.$initClass.'"'.$onClick.'>'.$label.'</a></span>';
+        return '<span class="atksectionwr"><a href="javascript:void(0)" id="'.$name.'" class="atksection"'.$onClick.'><i class="'.Config::getGlobal($initIcon).'" id="img_'.$name.'"></i> '.$label.'</a></span>';
     }
 
     /**

--- a/src/Resources/public/javascript/dhtml_tabs.js
+++ b/src/Resources/public/javascript/dhtml_tabs.js
@@ -30,15 +30,16 @@ function handleSectionToggle(element, expand, url) {
         }
     });
 
+    icon = $("img_"+element.id);
     if (expand) {
         var param = 'opened';
-        element.removeClassName('closedSection');
-        element.addClassName('openedSection');
+        icon.removeClassName('fa-plus-square-o');
+        icon.addClassName('fa-minus-square-o');
         closedSections = closedSections.without(element.id);
     } else {
         var param = 'closed';
-        element.removeClassName('openedSection');
-        element.addClassName('closedSection');
+        icon.removeClassName('fa-minus-square-o');
+        icon.addClassName('fa-plus-square-o');
         closedSections.push(element.id);
     }
 

--- a/src/Resources/public/javascript/dhtml_tabs.js
+++ b/src/Resources/public/javascript/dhtml_tabs.js
@@ -25,21 +25,22 @@ function handleSectionToggle(element, expand, url) {
     }).each(function (tr) {
         if (expand) {
             Element.show(tr);
-            element.removeClassName('closedSection');
-            element.addClassName('openedSection');
-            closedSections = closedSections.without(element.id);
         } else {
             Element.hide(tr);
-            element.removeClassName('openedSection');
-            element.addClassName('closedSection');
-            closedSections.push(element.id);
         }
     });
 
-    if (expand)
-        var param = 'opened'
-    else
-        var param = 'closed'
+    if (expand) {
+        var param = 'opened';
+        element.removeClassName('closedSection');
+        element.addClassName('openedSection');
+        closedSections = closedSections.without(element.id);
+    } else {
+        var param = 'closed';
+        element.removeClassName('openedSection');
+        element.addClassName('closedSection');
+        closedSections.push(element.id);
+    }
 
     new Ajax.Request(url, {
         method: 'get',

--- a/src/Resources/public/styles/style.css
+++ b/src/Resources/public/styles/style.css
@@ -9365,19 +9365,11 @@ A.atksection {
   font-size: 12px;
   font-weight: bold;
   text-decoration: none;
-  background-position: 2px 5px;
-  background-repeat: no-repeat;
   padding: 2px;
-  padding-left: 16px;
+  padding-left: 4px;
   width: 1px;
   white-space: nowrap;
   color: #000; }
-
-A.openedSection {
-  background-image: url("../images/minus.gif"); }
-
-A.closedSection {
-  background-image: url("../images/plus.gif"); }
 
 .ShuttleRelation .shuttle-controls {
   vertical-align: middle; }

--- a/src/Resources/src/sass/_sections.scss
+++ b/src/Resources/src/sass/_sections.scss
@@ -6,19 +6,9 @@ A.atksection {
     font-size: 12px;
     font-weight: bold;
     text-decoration: none;
-    background-position: 2px 5px;
-    background-repeat: no-repeat;
     padding: 2px;
-    padding-left: 16px;
+    padding-left: 4px;
     width: 1px;
     white-space: nowrap;
     color: #000;
-}
-
-A.openedSection {
-    background-image: url('../images/minus.gif');
-}
-
-A.closedSection {
-    background-image: url('../images/plus.gif');
 }


### PR DESCRIPTION
When closing/opening sections, there used to be icons (+/-). Since 4166bdf52caf8e2d37818665114943 i guess it doesn't work.

This PR fixes that by also using fontAwesome icons for section icons.