### PR TITLE
Fixing treenode functionality

### DIFF
--- a/src/Core/TreeNode.php
+++ b/src/Core/TreeNode.php
@@ -251,7 +251,6 @@ class TreeNode extends Node
                     $expand[$i] = 0;
                     $visible[$i] = 0;
                 }
-                $levels[$i] = 0;
             }
             if ($this->m_postvars['atktree'] != '') {
                 $explevels = explode('|', $this->m_postvars['atktree']);
@@ -260,7 +259,6 @@ class TreeNode extends Node
             for ($i = 0; $i < count($this->m_tree); ++$i) {
                 $expand[$i] = 1;
                 $visible[$i] = 1;
-                $levels[$i] = 0;
             }
             $this->m_tree[0]['expand'] = 0; // next time we are back in normal view mode!
         } elseif ($this->m_tree[0]['colapse'] == 1) { //  colapse all mode!
@@ -274,46 +272,23 @@ class TreeNode extends Node
                         $visible[$i] = 1;
                     }
                 }
-                $levels[$i] = 0;
             }
             $this->m_tree[0]['colapse'] = 0; // next time we are back in normal view mode!
         }
         /*         * ****************************************** */
         /*  Get Node numbers to expand               */
         /*         * ****************************************** */
-        $i = 0;
-        while ($i < count($explevels)) {
-            $expand[$exp_index[$explevels[$i]]] = 1;
-
-            ++$i;
+        foreach ($explevels as $explevel)
+        {
+            $expand[$exp_index[$explevel]] = 1;
         }
-        /*         * ****************************************** */
-        /*  Find last nodes of subtrees              */
-        /*         * ****************************************** */
 
-        $lastlevel = $g_maxlevel;
-
-        for ($i = count($this->m_tree) - 1; $i >= 0; --$i) {
-            if ($this->m_tree[$i]['level'] < $lastlevel) {
-                for ($j = $this->m_tree[$i]['level'] + 1; $j <= $g_maxlevel; ++$j) {
-                    $levels[$j] = 0;
-                }
-            }
-            if ($levels[$this->m_tree[$i]['level']] == 0) {
-                $levels[$this->m_tree[$i]['level']] = 1;
-                $this->m_tree[$i]['isleaf'] = 1;
-            } else {
-                $this->m_tree[$i]['isleaf'] = 0;
-            }
-            $lastlevel = $this->m_tree[$i]['level'];
-        }
         /*         * ****************************************** */
         /*  Determine visible nodes                  */
         /*         * ****************************************** */
-
         $visible[0] = 1;   // root is always visible
-        for ($i = 0; $i < count($explevels); ++$i) {
-            $n = $exp_index[$explevels[$i]];
+        foreach ($explevels as $explevel) {
+            $n = $exp_index[$explevel];
             if (($visible[$n] == 1) && ($expand[$n] == 1)) {
                 $j = $n + 1;
                 while ($this->m_tree[$j]['level'] > $this->m_tree[$n]['level']) {
@@ -325,15 +300,9 @@ class TreeNode extends Node
             }
         }
 
-        for ($i = 0; $i < $g_maxlevel; ++$i) {
-            $levels[$i] = 1;
-        }
-
         $res .= '<tr>';
         // Make cols for max level
-        for ($i = 0; $i < $g_maxlevel; ++$i) {
-            $res .= "<td width=23>&nbsp;</td>\n";
-        }
+        $res .= str_repeat("<td width=23>&nbsp;</td>\n", $g_maxlevel);
         // Make the last text column
         $res .= '<td width=300>&nbsp;</td>';
         // Column for the functions
@@ -355,17 +324,11 @@ class TreeNode extends Node
                 /****************************************/
                 /* vertical lines from higher levels    */
                 /****************************************/
-                $i = 0;
-                while ($i < $this->m_tree[$cnt]['level'] - 1) {
-                    $res .= "<td style='text-align:center'> │ </td>\n";
-                    ++$i;
-                }
-
                 if ($cnt != 0) {
                    $res .= "<td style='text-align:center'> │ </td>\n";
                 }
-                if ($this->m_tree[$cnt]['isleaf'] == 1 && $nextlevel < $currentlevel) {
-                    $levels[$this->m_tree[$cnt]['level'] - 1] = 0;
+                if ($this->m_tree[$cnt]['level'] - 1 >= 1) {
+                    $res .= str_repeat("<td style='text-align:center'> │ </td>\n", $this->m_tree[$cnt]['level'] - 1);
                 }
 
                 /*                 * ***************************************** */

--- a/src/Core/TreeNode.php
+++ b/src/Core/TreeNode.php
@@ -130,9 +130,10 @@ class TreeNode extends Node
                 $label = Tools::atktext('link_'.Tools::getNodeType($this->m_type).'_add', $this->m_module);
             } else {
                 // generic text
-                $label = Tools::atktext(Tools::getNodeType($this->m_type), $this->m_module).' '.Tools::atktext('add', 'atk');
+                $label = Tools::atktext('add', 'atk');
             }
-            $content .= Tools::href($addurl, $label, SessionManager::SESSION_NESTED).'<br><br>';
+            $cssClass = 'class="btn btn-default admin_link admin_link_add"';
+            $content .= Tools::href($addurl, $label, SessionManager::SESSION_NESTED, false, $cssClass).'<br><br>';
         }
 
         $content .= $this->GraphTreeRender();

--- a/src/Core/TreeNode.php
+++ b/src/Core/TreeNode.php
@@ -230,23 +230,12 @@ class TreeNode extends Node
             return '';
         }
 
-        $img_expand = $this->getIcon('expand');
-        $img_collapse = $this->getIcon('collapse');
-        $img_line = $this->getIcon('vertline');
-        $img_split = $this->getIcon('split');
-        $img_plus = $this->getIcon('split_plus');
-        $img_minus = $this->getIcon('split_minus');
-        $img_end = $this->getIcon('end');
-        $img_end_plus = $this->getIcon('end_plus');
-        $img_end_minus = $this->getIcon('end_minus');
-        $img_leaf = $this->getIcon('leaf');
-        $img_leaflink = $this->getIcon('leaf_link');
-        $img_spc = $this->getIcon('space');
-        $img_extfile = $this->getIcon('extfile');
+        $img_expand = Config::getGlobal('icon_expand');
+        $img_collapse = Config::getGlobal('icon_collapse');
+        $img_leaf = Config::getGlobal('icon_leaf');
 
         $res = '';
         $lastlevel = 0;
-        //echo $this->m_tree[0]["expand"]."--".$this->m_tree[0]["colapse"];
         $explevels = [];
         if ($this->m_tree[0]['expand'] != 1 && $this->m_tree[0]['colapse'] != 1) { // normal operation
             for ($i = 0; $i < count($this->m_tree); ++$i) {
@@ -294,7 +283,6 @@ class TreeNode extends Node
         /*         * ****************************************** */
         $i = 0;
         while ($i < count($explevels)) {
-            //$expand[$explevels[$i]]=1;
             $expand[$exp_index[$explevels[$i]]] = 1;
 
             ++$i;
@@ -344,7 +332,7 @@ class TreeNode extends Node
         $res .= '<tr>';
         // Make cols for max level
         for ($i = 0; $i < $g_maxlevel; ++$i) {
-            $res .= "<td width=16>&nbsp;</td>\n";
+            $res .= "<td width=23>&nbsp;</td>\n";
         }
         // Make the last text column
         $res .= '<td width=300>&nbsp;</td>';
@@ -369,100 +357,15 @@ class TreeNode extends Node
                 /****************************************/
                 $i = 0;
                 while ($i < $this->m_tree[$cnt]['level'] - 1) {
-                    if ($levels[$i] == 1) {
-                        $res .= '<td><img src="'.$img_line."\" border=0></td>\n";
-                    } else {
-                        $res .= '<td><img src="'.$img_spc."\" border=0></td>\n";
-                    }
+                    $res .= "<td style='text-align:center'> │ </td>\n";
                     ++$i;
                 }
 
-                /***************************************/
-                /* corner at end of subtree or t-split */
-                /***************************************/
+                if ($cnt != 0) {
+                   $res .= "<td style='text-align:center'> │ </td>\n";
+                }
                 if ($this->m_tree[$cnt]['isleaf'] == 1 && $nextlevel < $currentlevel) {
-                    if ($cnt != 0) {
-                        $res .= '<td><img src="'.$img_end."\" border=0></td>\n";
-                    }
                     $levels[$this->m_tree[$cnt]['level'] - 1] = 0;
-                } else {
-                    if ($expand[$cnt] == 0) {
-                        if ($nextlevel > $currentlevel) {
-                            /*                             * ************************************* */
-                            /* Create expand/collapse parameters    */
-                            /*                             * ************************************* */
-                            $i = 0;
-                            $params = 'atktree=';
-                            while ($i < count($expand)) {
-                                if (($expand[$i] == 1) && ($cnt != $i) || ($expand[$i] == 0 && $cnt == $i)) {
-                                    $params = $params.$this->m_tree[$i]['id'];
-                                    $params = $params.'|';
-                                }
-                                ++$i;
-                            }
-                            if ($this->extraparams) {
-                                $params = $params.$this->extraparams;
-                            }
-
-                            if ($this->m_tree[$cnt]['isleaf'] == 1) {
-                                if ($cnt != 0) {
-                                    $res .= '<td>'.Tools::href(Config::getGlobal('dispatcher').'?atknodeuri='.$this->atkNodeUri().'&atkaction='.$this->m_action.'&'.$params,
-                                            '<img src="'.$img_end_plus.'" border=0>')."</td>\n";
-                                }
-                            } else {
-                                if ($cnt != 0) {
-                                    $res .= '<td>'.Tools::href(Config::getGlobal('dispatcher').'?atknodeuri='.$this->atkNodeUri().'&atkaction='.$this->m_action.'&'.$params,
-                                            '<img src="'.$img_plus.'" border=0>')."</td>\n";
-                                }
-                            }
-                        } else {
-                            $res .= '<td><img src="'.$img_split."\" border=0></td>\n";
-                        }
-                    } else {
-                        if ($nextlevel > $currentlevel) {
-                            /*                             * ************************************* */
-                            /* Create expand/collapse parameters    */
-                            /*                             * ************************************* */
-                            $i = 0;
-                            $params = 'atktree=';
-                            while ($i < count($expand)) {
-                                if (($expand[$i] == 1) && ($cnt != $i) || ($expand[$i] == 0 && $cnt == $i)) {
-                                    $params = $params.$this->m_tree[$i]['id'];
-                                    $params = $params.'|';
-                                }
-                                ++$i;
-                            }
-                            if (isset($this->extraparams)) {
-                                $params = $params.$this->extraparams;
-                            }
-                            if ($this->m_tree[$cnt]['isleaf'] == 1) {
-                                if ($cnt != 0) {
-                                    if ($foldable) {
-                                        $res .= '<td>'.Tools::href(Config::getGlobal('dispatcher').'?atknodeuri='.$this->atkNodeUri().'&atkaction='.$this->m_action.'&'.$params,
-                                                '<img src="'.$img_end_minus.'" border=0>')."</td>\n";
-                                    } else {
-                                        $res .= '<td><img src="'.$img_end."\" border=0></td>\n";
-                                    }
-                                }
-                            } else {
-                                if ($cnt != 0) {
-                                    if ($foldable) {
-                                        $res .= '<td>'.Tools::href(Config::getGlobal('dispatcher').'?atknodeuri='.$this->atkNodeUri().'&atkaction='.$this->m_action.'&'.$params,
-                                                '<img src="'.$img_minus.'" border=0>')."</td>\n";
-                                    } else {
-                                        $res .= '<td><img src="'.$img_split."\" border=0></td>\n";
-                                    }
-                                }
-                            }
-                        } else {
-                            $res .= '<td><img src="'.$img_split."\" border=0></td>\n";
-                        }
-                    }
-                    if ($this->m_tree[$cnt]['isleaf'] == 1) {
-                        $levels[$this->m_tree[$cnt]['level'] - 1] = 0;
-                    } else {
-                        $levels[$this->m_tree[$cnt]['level'] - 1] = 1;
-                    }
                 }
 
                 /*                 * ***************************************** */
@@ -486,12 +389,12 @@ class TreeNode extends Node
                             $params = $params.$this->extraparams;
                         }
                         if ($expand[$cnt] == 0) {
-                            $res .= '<td>'.Tools::href(Config::getGlobal('dispatcher').'?'.$params, '<img src="'.$img_expand.'" border=0>')."</td>\n";
+                            $res .= '<td>'.Tools::href(Config::getGlobal('dispatcher').'?'.$params, '<i class="fa fa-'.$img_expand.'"></i>', SessionManager::SESSION_DEFAULT, false, 'class="btn btn-default"')."</td>\n";
                         } else {
-                            $res .= '<td>'.Tools::href(Config::getGlobal('dispatcher').'?'.$params, '<img src="'.$img_collapse.'" border=0>')."</td>\n";
+                            $res .= '<td>'.Tools::href(Config::getGlobal('dispatcher').'?'.$params, '<i class="fa fa-'.$img_collapse.'"></i>', SessionManager::SESSION_DEFAULT, false, 'class="btn btn-default"')."</td>\n";
                         }
                     } else {
-                        $res .= '<td><img src="'.$img_collapse."\" border=0></td>\n";
+                        $res .= '<td><i class="fa fa-'.$img_collapse."\"></i></td>\n";
                     }
                 } else {
                     /*                     * ********************** */
@@ -503,7 +406,7 @@ class TreeNode extends Node
                         $imgname = $this->m_tree[$cnt]['img'];
                         $img = $$imgname;
                     }
-                    $res .= '<td><img src="'.$img."\"></td>\n";
+                    $res .= '<td style="text-align:center"><i class="fa fa-'.$img."\"></i></td>\n";
                 }
 
                 /*                 * ************************************* */

--- a/src/Relations/ManyToOneTreeRelation.php
+++ b/src/Relations/ManyToOneTreeRelation.php
@@ -18,7 +18,6 @@ use Sintattica\Atk\Utils\StringParser;
 class ManyToOneTreeRelation extends ManyToOneRelation
 {
     public $m_current = '';
-    public $m_level = '';
 
     /**
      * Constructor.
@@ -96,10 +95,9 @@ class ManyToOneTreeRelation extends ManyToOneRelation
     public function createdd($recordset, $value = '')
     {
         $t = new TreeToolsTree();
-        for ($i = 0; $i < count($recordset); ++$i) {
-            $group = $recordset[$i];
-            $t->addNode($recordset[$i][$this->m_destInstance->m_primaryKey[0]], $this->m_destInstance->descriptor($group),
-                $recordset[$i][$this->m_destInstance->m_parent][$this->m_destInstance->m_primaryKey[0]]);
+        foreach ($recordset as $record) {
+            $t->addNode($record[$this->m_destInstance->m_primaryKey[0]], $this->m_destInstance->descriptor($record),
+                $record[$this->m_destInstance->m_parent][$this->m_destInstance->m_primaryKey[0]]);
         }
         $tmp = $this->render($t->m_tree, $value);
 
@@ -119,10 +117,8 @@ class ManyToOneTreeRelation extends ManyToOneRelation
         $res = '';
         while (list(, $objarr) = each($tree)) {
             $sel = '';
-            if ($this->m_current != $this->m_destInstance->m_table.'.'.$this->m_destInstance->m_primaryKey[0]."='".$objarr->m_id."'") {
-                $this->m_level = $level;
-                $dis = '';
-            } else {
+            $dis = '';
+            if ($this->m_current == $this->m_destInstance->m_table.'.'.$this->m_destInstance->m_primaryKey[0]."='".$objarr->m_id."'") {
                 // if equal, disable the option it and do not render childs (parent cannot be moved to a childnode of its own)
                 $dis = 'DISABLED';
             }
@@ -137,7 +133,6 @@ class ManyToOneTreeRelation extends ManyToOneRelation
                 $res .= $this->render($objarr->m_sub, $value, $level + 1);
             }
         }
-        $this->m_level = 0;
 
         return $res;
     }

--- a/src/Resources/config/atk.php
+++ b/src/Resources/config/atk.php
@@ -878,6 +878,9 @@ return [
     'icon_print' => 'fa fa-print',
     'icon_plussquare' => 'fa fa-plus-square-o',
     'icon_minussquare' => 'fa fa-minus-square-o',
+    'icon_expand' => 'angle-down',
+    'icon_collapse' => 'angle-up',
+    'icon_leaf' => 'angle-right',
 
     /****************** CACHING ********************/
 


### PR DESCRIPTION
In 9.0, treenodes do not work. These commits fix different parts : 
- 26583c3 fixes icons (reducing the schema to 4 icons, abandoning the "directory/file" metaphor for simple arrows)
- 6d71cb7 and dfe1e79 : simplifying code
- a73934aadde05fb729e4ad426a405fc6d82a1407 : in TreeNode, fixing copyDb and shrinking deleteDb to be recursive in itself and using parent::deleteDb for the most part (without any change to Node::deleteDb.)
- f5e1e7c : parent selection form in ManyToOneTreeRelation not passign values as "table.column_id='xx'" anymore, which i suspect is better for security but I'm not a specialist. This is the more debatable commit i think.

![screenshot](https://user-images.githubusercontent.com/36996277/52738363-c7996c80-2fce-11e9-818d-fd557d757240.png)
