### PR TITLE
Fix bug with many-To-Many relations and 'date' primary keys

### DIFF
--- a/src/Relations/ManyToManyRelation.php
+++ b/src/Relations/ManyToManyRelation.php
@@ -612,12 +612,10 @@ class ManyToManyRelation extends Relation
 
         if (is_array($localKey)) {
             for ($j = 0; $j < Tools::count($localKey); ++$j) {
-                $locKey = $this->checkKeyDimension($ownerRecord[$ownerFields[$j]]);
-                $record[$localKey[0]][$ownerFields[$j]] = $locKey;
+                $record[$localKey[0]][$ownerFields[$j]] = $ownerRecord[$ownerFields[$j]];
             }
         } else {
-            $locKey = $this->checkKeyDimension($ownerRecord[$ownerFields[0]]);
-            $record[$localKey] = $locKey;
+            $record[$localKey] = $ownerRecord[$ownerFields[$j]];
         }
 
         return $record;


### PR DESCRIPTION
Small fix for an edge-case bug when you have :
- a primary key on a 'date' field
- this key is used in many-to-many relations.

This may not be very common, but as long as it is made possible by the framework, let's fix that.

Note that this bug was found while coding [a test](https://framagit.org/samuelbf/atk-testsuite/blob/master/tests/RelationsTest.php#L242) for [ATK testsuite](https://framagit.org/samuelbf/atk-testsuite/), a initiative to provide automated tests for ATK framework.