### PR TITLE
Fix search with 'none' and other value for M2O.

### DIFF
--- a/src/Attributes/MultiSelectAttribute.php
+++ b/src/Attributes/MultiSelectAttribute.php
@@ -39,7 +39,7 @@ class MultiSelectAttribute extends ListAttribute
     public function __construct($name, $flags = 0, $optionArray, $valueArray = null)
     {
         parent::__construct($name, $flags, $optionArray, $valueArray);
-        
+
         $size = 0;
         $valueArray = $this->getValues();
         for ($i = 0, $_i = Tools::count($valueArray); $i < $_i; ++$i) {
@@ -203,7 +203,11 @@ class MultiSelectAttribute extends ListAttribute
         if (is_array($value) && $value[0] != '' && Tools::count($value) > 0) {
             $searchcondition = [];
             foreach ($value as $str) {
-                $searchcondition[] = $query->substringCondition($table.'.'.$this->fieldName(), $this->escapeSQL($str));
+                if ($str == '__NONE__') {
+                    $searchcondition[] = $query->nullCondition($table.'.'.$this->fieldName(), true);
+                } else {
+                    $searchcondition[] = $query->substringCondition($table.'.'.$this->fieldName(), $this->escapeSQL($str));
+                }
             }
             $searchcondition = implode(' OR ', $searchcondition);
         }

--- a/src/Relations/ManyToOneRelation.php
+++ b/src/Relations/ManyToOneRelation.php
@@ -1331,7 +1331,13 @@ EOF;
                         return $query->exactCondition($table.'.'.$this->fieldName(), $this->escapeSQL($value[0]), $this->dbFieldType());
                     }
                 } else { // search for more values using IN()
-                    return $table.'.'.$this->fieldName()." IN ('".implode("','", $value)."')";
+                    $keyNone = array_search('__NONE__', $value);
+                    $condition = '';
+                    if ($keyNone !== FALSE) {
+                        $condition = $query->nullCondition($table.'.'.$this->fieldName(), true).' OR ';
+                        unset($value[$keyNone]);
+                    }
+                    return $condition.$table.'.'.$this->fieldName()." IN ('".implode("','", $value)."')";
                 }
             } else { // AF_LARGE || AF_RELATION_AUTOCOMPLETE
 


### PR DESCRIPTION
For a list M2O attribute, when you search for several attribute and one of the attribute is 'none', current code mistreat 'none' as a '__NONE__' search.

This patch fixes that. I've included the same fix in #41 .

This bug was found while coding [the corresponding test](https://framagit.org/samuelbf/atk-testsuite/blob/master/tests/SearchTest.php#L309) in [testsuite](https://framagit.org/samuelbf/atk-testsuite/).