### PR TITLE
Improving tabs and section handling

### DIFF
--- a/doc/CHANGES
+++ b/doc/CHANGES
@@ -15,6 +15,7 @@ Bug numbers are references to bugs in the ibuildings Bugzilla bug tracker:
 
 WIP Changes
 -----------
+- Removed \Ui\Page->register_hiddenvars and associated functions [samuel]
 * Fixed stateful tabs (per node, not per-selector) [samuel]
 
 

--- a/doc/CHANGES
+++ b/doc/CHANGES
@@ -15,6 +15,7 @@ Bug numbers are references to bugs in the ibuildings Bugzilla bug tracker:
 
 WIP Changes
 -----------
+* Fixed stateful tabs (per node, not per-selector) [samuel]
 
 
 New Release ATK 9.0 (2016-03-09)

--- a/doc/CHANGES
+++ b/doc/CHANGES
@@ -15,6 +15,7 @@ Bug numbers are references to bugs in the ibuildings Bugzilla bug tracker:
 
 WIP Changes
 -----------
+* Tab order should now be set with node->setTabOrder($tab, $order, $action) [samuel]
 - Removed \Ui\Page->register_hiddenvars and associated functions [samuel]
 * Fixed stateful tabs (per node, not per-selector) [samuel]
 

--- a/src/Attributes/Attribute.php
+++ b/src/Attributes/Attribute.php
@@ -1191,6 +1191,12 @@ class Attribute
         }
 
         $this->m_tabs = $tabs;
+        $this->m_ownerInstance->addTabs(
+            $tabs,
+            !$this->hasFlag(Attribute::AF_HIDE_VIEW),
+            !$this->hasFlag(Attribute::AF_HIDE_ADD),
+            !$this->hasFlag(Attribute::AF_HIDE_EDIT)
+        );
 
         return $this;
     }
@@ -1222,6 +1228,14 @@ class Attribute
             $this->m_sections = [];
         } else {
             $this->m_sections = $sections;
+            $this->m_ownerInstance->addSections(
+                $sections,
+                !$this->hasFlag(Attribute::AF_HIDE_VIEW),
+                !$this->hasFlag(Attribute::AF_HIDE_ADD),
+                !$this->hasFlag(Attribute::AF_HIDE_EDIT)
+            );
+            $tabs = $this->m_ownerInstance->getTabsFromSections($sections);
+            $this->setTabs($tabs);
         }
 
         return $this;

--- a/src/Attributes/Attribute.php
+++ b/src/Attributes/Attribute.php
@@ -388,13 +388,6 @@ class Attribute
     public $m_order = 0;
 
     /*
-     * Index of the attribute within its node.
-     * @access private
-     * @var int
-     */
-    public $m_index = 0;
-
-    /*
      * The tabs on which the attribute lives. If section is set, this
      * value is ignored.
      * '' stands for default tab.
@@ -1301,9 +1294,33 @@ class Attribute
      *
      * @return Attribute The instance of this Attribute
      */
-    public function setTabs(array $tabs) {
+    public function setTabs(array $tabs)
+    {
         $this->m_tabs = $tabs;
         return $this;
+    }
+
+    /**
+     * Set the order of the attribute inside its section or tabs
+     *
+     * @param int $order
+     *
+     * @return Attribute The instance of this Attribute
+     */
+    public function setOrder(int $order)
+    {
+        $this->m_order = $order;
+        return $this;
+    }
+
+    /**
+     * Get the order of the attribute within its section or tabs
+     *
+     * @return int $order
+     */
+    public function getOrder()
+    {
+        return $this->m_order;
     }
 
     /**
@@ -1460,8 +1477,11 @@ class Attribute
      */
     public function getError($errors)
     {
-        for ($i = 0; $i < Tools::count($errors); ++$i) {
-            if ($errors[$i]['attrib_name'] == $this->fieldName() || Tools::atk_in_array($this->fieldName(), $errors[$i]['attrib_name'])) {
+        if (!is_array($errors)) {
+            return false;
+        }
+        foreach ($errors as $error) {
+            if ($error['attrib_name'] == $this->fieldName() || Tools::atk_in_array($this->fieldName(), $error['attrib_name'])) {
                 return true;
             }
         }

--- a/src/Attributes/Attribute.php
+++ b/src/Attributes/Attribute.php
@@ -534,13 +534,6 @@ class Attribute
      */
     public $m_initialValue = null;
 
-    /**
-     * Column.
-     *
-     * @var string
-     */
-    private $m_column;
-
 
     /**
      * View callback.
@@ -1242,30 +1235,6 @@ class Attribute
     public function getSections()
     {
         return $this->m_sections;
-    }
-
-    /**
-     * Get column.
-     *
-     * @return string column name
-     */
-    public function getColumn()
-    {
-        return $this->m_column;
-    }
-
-    /**
-     * Set column.
-     *
-     * @param string $name column name
-     *
-     * @return Attribute The instance of this Attribute
-     */
-    public function setColumn($name)
-    {
-        $this->m_column = $name;
-
-        return $this;
     }
 
     /**

--- a/src/Attributes/Attribute.php
+++ b/src/Attributes/Attribute.php
@@ -1083,6 +1083,7 @@ class Attribute
         if (!is_null($this->m_section)) {
             $section = $this->m_ownerInstance->resolveSection($this->m_section);
             $this->addRowCSSClass('section_'.str_replace('.', '_', $section));
+            $tabs = [$this->m_ownerInstance->getTabFromSection($section)];
         } else {
             foreach ($this->m_tabs as $tab) {
                 $tab = $this->m_ownerInstance->resolveTab($tab);

--- a/src/Attributes/FieldSet.php
+++ b/src/Attributes/FieldSet.php
@@ -26,12 +26,12 @@ class FieldSet extends Attribute
     {
         $flags = $flags | self::AF_NO_SORT | self::AF_HIDE_SEARCH;
         parent::__construct($name, $flags);
-        
+
         $this->setTemplate($template);
         $this->setLoadType(self::NOLOAD);
         $this->setStorageType(self::NOSTORE);
     }
-    
+
     public function isEmpty($record)
     {
         // always return false, this way you can mark a field-set as obligatory
@@ -110,7 +110,7 @@ class FieldSet extends Attribute
             $attr = $this->getOwnerInstance()->getAttribute($attrName);
             $attr->addDisabledMode(self::DISABLED_VIEW | self::DISABLED_EDIT);
             $attr->setTabs($this->getTabs());
-            $attr->setSections($this->getSections());
+            $attr->setSection($this->getSection());
         }
     }
 

--- a/src/Attributes/TabbedPane.php
+++ b/src/Attributes/TabbedPane.php
@@ -75,7 +75,7 @@ class TabbedPane extends Attribute
             if (is_object($p_attr)) {
                 $p_attr->addDisabledMode(self::DISABLED_VIEW | self::DISABLED_EDIT);
                 $p_attr->setTabs($this->getTabs());
-                $p_attr->setSections($this->getSections());
+                $p_attr->setSection($this->getSection());
             }
         }
     }
@@ -149,7 +149,7 @@ class TabbedPane extends Attribute
             $p_attr = $this->m_ownerInstance->getAttribute($attrib);
             $p_attr->addDisabledMode(self::DISABLED_VIEW | self::DISABLED_EDIT);
             $p_attr->setTabs($this->getTabs());
-            $p_attr->setSections($this->getSections());
+            $p_attr->setSection($this->getSection());
         }
     }
 
@@ -256,7 +256,7 @@ class TabbedPane extends Attribute
                         // on which tab? - from tabbedpane properties
                         $entry['tabs'] = $tab;
                         //on which sections?
-                        $entry['sections'] = $p_attrib->getSections();
+                        $entry['section'] = $p_attrib->getSection();
                         /* the actual edit contents */
                         $entry['html'] = $p_attrib->getView($mode, $defaults);
                         $arr['fields'][] = $entry;

--- a/src/Core/Node.php
+++ b/src/Core/Node.php
@@ -2807,12 +2807,12 @@ class Node
      * @param array $record The master record being stored.
      * @param string $mode The storage mode ("add", "copy" or "update")
      *
-     * @return bool True if succesful, false if not.
+     * @return bool True if successful, false if not.
      */
     public function _storeAttributes($storelist, &$record, $mode)
     {
         // store special storage attributes.
-        foreach ($storelist as $attribnam) {
+        foreach ($storelist as $attribname) {
             $p_attrib = $this->m_attribList[$attribname];
             if (!$p_attrib->store($this->getDb(), $record, $mode)) {
                 // something went wrong.

--- a/src/Core/NodeValidator.php
+++ b/src/Core/NodeValidator.php
@@ -111,8 +111,7 @@ class NodeValidator
 
         // Check flags and values
         $db = $this->m_nodeObj->getDb();
-        foreach ($this->m_nodeObj->m_attribIndexList as $attribdata) {
-            $attribname = $attribdata['name'];
+        foreach (array_keys($this->m_nodeObj->getAttributes()) as $attribname) {
             if (!Tools::atk_in_array($attribname, $this->m_ignoreList)) {
                 $p_attrib = $this->m_nodeObj->m_attribList[$attribname];
 

--- a/src/Core/Tools.php
+++ b/src/Core/Tools.php
@@ -900,18 +900,19 @@ class Tools
                 $label[$i] = $attrib[$i]->label();
             }
 
-            $tab = $attrib[0]->m_tabs[0];
+            $tab = $attrib[0]->getTabs()[0];
             if (!$message) {
                 $message = $attrib[0]->text($error);
             }
         } else {
             $attribName = $attrib->fieldName();
             $label = $attrib->label();
-            $tab = $attrib->m_tabs[0];
+            $tab = $attrib->getTabs()[0];
             if (!$message) {
                 $message = $attrib->text($error);
             }
         }
+        $tab = $attrib->getOwnerInstance()->resolveTab($tab);
 
         self::triggerError($record, $attribName, $error, $message, $tab, $label);
     }

--- a/src/Handlers/AddHandler.php
+++ b/src/Handlers/AddHandler.php
@@ -341,4 +341,15 @@ class AddHandler extends ActionHandler
             'section' => $this->m_postvars['atksectionname'],
         ), $this->m_postvars['atksectionstate']);
     }
+
+    /**
+     * Partial handler for changing default tab
+     */
+    public function partial_tabstate()
+    {
+        if (Config::getGlobal('dhtml_tabs_stateful')) {
+            State::set($this->m_node->atkNodeUri().'_tab', $this->m_postvars['atktab']);
+        }
+        die;
+    }
 }

--- a/src/Handlers/AddHandler.php
+++ b/src/Handlers/AddHandler.php
@@ -226,9 +226,7 @@ class AddHandler extends ActionHandler
         $edithandler = $node->getHandler('edit');
 
         $forceList = $this->invoke('createForceList');
-        $form = $edithandler->editForm('add', $record, $forceList, '', $node->getEditFieldPrefix());
-
-        return $node->tabulate('add', $form);
+        return $edithandler->editForm('add', $record, $forceList, '', $node->getEditFieldPrefix());
     }
 
     /**

--- a/src/Handlers/EditHandler.php
+++ b/src/Handlers/EditHandler.php
@@ -338,10 +338,8 @@ class EditHandler extends ViewEditBase
 
         // Format some things for use in tpl.
         /* check for errors and display them */
-        $tab = $this->getActiveTab($param['fields'], $mode);
         $error_title = '';
         $pk_err_attrib = [];
-        $tabs = $this->getTabs($params['fields']);
         $errorFields = [];
 
         // Handle errors
@@ -353,7 +351,7 @@ class EditHandler extends ViewEditBase
                 if ($error['err'] == 'error_primarykey_exists') {
                     $pk_err_attrib[] = $error['attrib_name'];
                 } else {
-                    if (Tools::count($tabs) > 1 && $error['tab']) {
+                    if (Tools::count($params['tabs']) > 1 && $error['tab']) {
                         $tabLink = $this->getTabLink($node, $error);
                         $error_tab = ' ('.Tools::atktext('error_tab').' '.$tabLink.' )';
                     } else {
@@ -426,8 +424,6 @@ class EditHandler extends ViewEditBase
             $result .= $hidden;
         }
 
-        $params['activeTab'] = $tab;
-        $params['fields'] = $this->fieldsWithTabsAndSections($data['fields']); // add all fields as a numeric array.
         $result .= $this->tabulate('edit', $params['fields']);
 
         $params['errortitle'] = $error_title;
@@ -436,7 +432,7 @@ class EditHandler extends ViewEditBase
         if ($template) {
             $result .= $ui->render($template, $params);
         } else {
-            $tabTpl = $this->_getTabTpl($node, $tabs, $mode, $record);
+            $tabTpl = $this->_getTabTpl($node, $params['tabs'], $mode, $record);
             $params['fieldspart'] = $this->_renderTabs($params['fields'], $tabTpl);
             $result .= $ui->render('editform_common.tpl', $params);
         }

--- a/src/Handlers/EditHandler.php
+++ b/src/Handlers/EditHandler.php
@@ -428,6 +428,7 @@ class EditHandler extends ViewEditBase
 
         $params['activeTab'] = $tab;
         $params['fields'] = $this->fieldsWithTabsAndSections($data['fields']); // add all fields as a numeric array.
+        $result .= $this->tabulate('edit', $params['fields']);
 
         $params['errortitle'] = $error_title;
         $params['errors'] = $errors; // Add the list of errors.
@@ -440,7 +441,7 @@ class EditHandler extends ViewEditBase
             $result .= $ui->render('editform_common.tpl', $params);
         }
 
-        return $this->tabulate('edit', $params['fields'], $result);
+        return $result;
     }
 
     /**

--- a/src/Handlers/EditHandler.php
+++ b/src/Handlers/EditHandler.php
@@ -464,7 +464,7 @@ class EditHandler extends ViewEditBase
         $data = $node->editArray($mode, $record, $forceList, $suppressList, $fieldprefix, $ignoreTab);
         // Format some things for use in tpl.
         /* check for errors and display them */
-        $tab = $node->getActiveTab();
+        $tab = $node->getActiveTab($mode);
         $error_title = '';
         $pk_err_attrib = [];
         $tabs = $node->getTabs($node->m_action);

--- a/src/Handlers/EditHandler.php
+++ b/src/Handlers/EditHandler.php
@@ -416,9 +416,6 @@ class EditHandler extends ViewEditBase
 
             $tplfield['full'] = $editsrc;
 
-            $column = $field['attribute']->getColumn();
-            $tplfield['column'] = $column;
-
             $tplfield['readonly'] = $field['attribute']->isReadonlyEdit($mode);
 
             $tplfield['help'] = $field['attribute']->getHelp();

--- a/src/Handlers/EditHandler.php
+++ b/src/Handlers/EditHandler.php
@@ -334,11 +334,11 @@ class EditHandler extends ViewEditBase
         $params = [];
         $params['fields'] = $this->fieldsWithTabsAndSections($data['fields']); // add all fields as a numeric array.
         $params['tabs'] = $this->getTabs($params['fields']);
-        $params['activeTab'] = $this->getActiveTab($mode);
+        $params['activeTab'] = $this->getActiveTab($param['fields'], $mode);
 
         // Format some things for use in tpl.
         /* check for errors and display them */
-        $tab = $this->getActiveTab($mode);
+        $tab = $this->getActiveTab($param['fields'], $mode);
         $error_title = '';
         $pk_err_attrib = [];
         $tabs = $this->getTabs($params['fields']);

--- a/src/Handlers/UpdateHandler.php
+++ b/src/Handlers/UpdateHandler.php
@@ -106,8 +106,7 @@ class UpdateHandler extends ActionHandler
                 $sm = SessionManager::getInstance();
                 // something other than one of the three buttons was pressed. Let's just refresh.
                 $location = $sm->sessionUrl(Tools::dispatch_url($this->m_node->atkNodeUri(), $this->getEditAction(), array(
-                    'atkselector' => $this->m_node->primaryKey($record),
-                    'atktab' => $this->m_node->getActiveTab(),
+                    'atkselector' => $this->m_node->primaryKey($record)
                 )), SessionManager::SESSION_REPLACE);
                 $this->m_node->redirect($location);
             }
@@ -321,8 +320,7 @@ class UpdateHandler extends ActionHandler
         if (isset($this->m_postvars['atknoclose'])) {
             // 'save' was clicked
             $params = array(
-                'atkselector' => $this->m_node->primaryKey($record),
-                'atktab' => $this->m_node->getActiveTab(),
+                'atkselector' => $this->m_node->primaryKey($record)
             );
             $sm = SessionManager::getInstance();
             $location = $sm->sessionUrl(Tools::dispatch_url($this->m_node->atkNodeUri(), $this->getEditAction(), $params), SessionManager::SESSION_REPLACE, 1);

--- a/src/Handlers/ViewEditBase.php
+++ b/src/Handlers/ViewEditBase.php
@@ -149,10 +149,7 @@ class ViewEditBase extends ActionHandler
         $initIcon = 'icon_minussquare';
 
         //if the section is not active, we close it on load.
-        $default = in_array($field['name'], $this->m_node->getActiveSections($tab, $mode)) ? 'opened' : 'closed';
-        $sectionstate = State::get(array('nodetype' => $this->m_node->atkNodeUri(), 'section' => $name), $default);
-
-        if ($sectionstate == 'closed') {
+        if (!in_array($field['name'], $this->m_node->getActiveSections($tab, $mode))) {
             $initIcon = 'icon_plussquare';
             $page = $this->getPage();
             $page->register_scriptcode("ATK.Tabs.addClosedSection('$name');");
@@ -225,6 +222,17 @@ class ViewEditBase extends ActionHandler
             'nodetype' => $this->m_node->atkNodeUri(),
             'section' => $this->m_postvars['atksectionname'],
         ), $this->m_postvars['atksectionstate']);
+        die;
+    }
+
+    /**
+     * Tab state handler.
+     */
+    public function partial_tabstate()
+    {
+        if (Config::getGlobal('dhtml_tabs_stateful')) {
+            State::set($this->m_node->atkNodeUri().'_tab', $this->m_postvars['atktab']);
+        }
         die;
     }
 

--- a/src/Handlers/ViewEditBase.php
+++ b/src/Handlers/ViewEditBase.php
@@ -419,16 +419,14 @@ class ViewEditBase extends ActionHandler
     }
 
     /**
-     * Place a set of tabs around content.
+     * Render tabs header with their links.
      *
      * @param string $action The action for which the tabs are loaded.
      * @param array $fields as returned by node->editArray of node->viewArray()
-     * @param string $content The content that is to be displayed within the
-     *                        tabset.
      *
      * @return string The complete tabset with content.
      */
-    public function tabulate($action, $fields, $content)
+    public function tabulate($action, $fields)
     {
         // Collect tabs from fields shown in the form :
         $tabs = $this->getTabs($fields);
@@ -436,18 +434,18 @@ class ViewEditBase extends ActionHandler
         $tabCount = Tools::count($tabs);
 
         if (!$this->m_hasSections && $tabCount == 1) {
-            return $content;
+            return '';
         }
 
         $page = $this->getPage();
         $page->register_script(Config::getGlobal('assets_url').'javascript/tabs.js');
 
         if ($tabCount == 1) {
-            return $content;
+            return '';
         }
         $ui = $this->getUi();
         if (!is_object($ui)) {
-            return $content;
+            return '';
         }
 
         // which tab is currently selected
@@ -463,7 +461,6 @@ class ViewEditBase extends ActionHandler
         }
         return $ui->renderTabs([
             'tabs' => $tabList,
-            'content' => $content,
             'tabstateUrl' => Config::getGlobal('dispatcher').'?atknodeuri='.$this->m_node->atkNodeUri().'&atkaction='.$action.'&atkpartial=tabstate&atktab=',
         ]);
     }

--- a/src/Handlers/ViewEditBase.php
+++ b/src/Handlers/ViewEditBase.php
@@ -352,7 +352,7 @@ class ViewEditBase extends ActionHandler
         }
 
         // We retain the information 'is there at least one section' (for tabulate function, later).
-        $this->m_hasSection = !empty($fieldsBySection);
+        $this->m_hasSections = !empty($fieldsBySection);
 
         // Let's put the fields outside sections in the beginning of the result
         $result = $fieldsWithoutSection;

--- a/src/Handlers/ViewEditBase.php
+++ b/src/Handlers/ViewEditBase.php
@@ -6,6 +6,7 @@ use Sintattica\Atk\Session\SessionManager;
 use Sintattica\Atk\Core\Tools;
 use Sintattica\Atk\Session\State;
 use Sintattica\Atk\Core\Node;
+use Sintattica\Atk\Core\Config;
 use Sintattica\Atk\Session\SessionStore;
 
 /**
@@ -145,20 +146,20 @@ class ViewEditBase extends ActionHandler
 
         // create onclick statement.
         $onClick = " onClick=\"javascript:ATK.Tabs.handleSectionToggle(this,null,'{$url}'); return false;\"";
-        $initClass = 'openedSection';
+        $initIcon = 'icon_minussquare';
 
         //if the section is not active, we close it on load.
         $default = in_array($field['name'], $this->m_node->getActiveSections($tab, $mode)) ? 'opened' : 'closed';
         $sectionstate = State::get(array('nodetype' => $this->m_node->atkNodeUri(), 'section' => $name), $default);
 
         if ($sectionstate == 'closed') {
-            $initClass = 'closedSection';
+            $initIcon = 'icon_plussquare';
             $page = $this->getPage();
             $page->register_scriptcode("ATK.Tabs.addClosedSection('$name');");
         }
 
         // create the clickable link
-        return '<span class="atksectionwr"><a href="javascript:void(0)" id="'.$name.'" class="atksection '.$initClass.'"'.$onClick.'>'.$label.'</a></span>';
+        return '<span class="atksectionwr"><a href="javascript:void(0)" id="'.$name.'" class="atksection"'.$onClick.'><i class="'.Config::getGlobal($initIcon).'" id="img_'.$name.'"></i> '.$label.'</a></span>';
     }
 
     /**

--- a/src/Handlers/ViewHandler.php
+++ b/src/Handlers/ViewHandler.php
@@ -156,7 +156,7 @@ class ViewHandler extends ViewEditBase
         $fields = $this->fieldsWithTabsAndSections($data['fields']);
         $tabHeader = $this->tabulate('view', $fields);
         // get active tab
-        $tab = $this->getActiveTab();
+        $tab = $this->getActiveTab($fields, $mode);
         // get all tabs of current mode
         $tabs = $this->getTabs($fields);
 

--- a/src/Handlers/ViewHandler.php
+++ b/src/Handlers/ViewHandler.php
@@ -84,13 +84,10 @@ class ViewHandler extends ViewEditBase
 
         if (is_object($ui)) {
             $params = $node->getDefaultActionParams();
-            $tab = $node->getActiveTab('view');
-            $innerform = $this->viewForm($record, 'view');
 
-            $params['activeTab'] = $tab;
             $params['header'] = $this->invoke('viewHeader', $record);
             $params['title'] = $node->actionTitle($this->m_action, $record);
-            $params['content'] = $node->tabulate('view', $innerform);
+            $params['content'] = $this->viewForm($record, 'view');
 
             $params['formstart'] = $this->getFormStart($record);
             $params['buttons'] = $this->getFormButtons($record);
@@ -156,113 +153,27 @@ class ViewHandler extends ViewEditBase
         // get data, transform into form, return
         $data = $node->viewArray($mode, $record);
 
+        $fields = $this->fieldsWithTabsAndSections($data['fields']);
         // get active tab
-        $tab = $node->getActiveTab();
+        $tab = $this->getActiveTab();
         // get all tabs of current mode
-        $tabs = $node->getTabs($mode);
+        $tabs = $this->getTabs($fields);
 
-        $fields = [];
-        $attributes = [];
-
-        // For all attributes we use the display() function to display the
-        // attributes current value. This may be overridden by supplying
-        // an <attributename>_display function in the derived classes.
-        for ($i = 0, $_i = Tools::count($data['fields']); $i < $_i; ++$i) {
-            $field = &$data['fields'][$i];
-            $tplfield = [];
-
-            $classes = [];
-            if ($field['sections'] == '*') {
-                $classes[] = 'alltabs';
-            } else {
-                if ($field['html'] == 'section') {
-                    // section should only have the tab section classes
-                    foreach ($field['tabs'] as $section) {
-                        $classes[] = 'section_'.str_replace('.', '_', $section);
-                    }
-                } else {
-                    if (is_array($field['sections'])) {
-                        foreach ($field['sections'] as $section) {
-                            $classes[] = 'section_'.str_replace('.', '_', $section);
-                        }
-                    }
-                }
-            }
-
-            $tplfield['class'] = implode(' ', $classes);
-            $tplfield['tab'] = $tplfield['class']; // for backwards compatibility
-            // visible sections, both the active sections and the tab names (attribute that are
-            // part of the anonymous section of the tab)
-            $visibleSections = array_merge($this->m_node->getActiveSections($tab, $mode), $tabs);
-
-            // Todo fixme: initial_on_tab kan er uit, als er gewoon bij het opstarten al 1 keer showTab aangeroepen wordt (is netter dan aparte initial_on_tab check)
-            // maar, let op, die showTab kan pas worden aangeroepen aan het begin.
-            $tplfield['initial_on_tab'] = ($field['tabs'] == '*' || in_array($tab,
-                        $field['tabs'])) && (!is_array($field['sections']) || Tools::count(array_intersect($field['sections'], $visibleSections)) > 0);
-
-            // Give the row an id if it doesn't have one yet
-            if (!isset($field['id']) || empty($field['id'])) {
-                $field['id'] = Tools::getUniqueId('anonymousattribrows');
-            }
-
-            // ar_ stands voor 'attribrow'.
-            $tplfield['rowid'] = 'ar_'.$field['id']; // The id of the containing row
-
-            /* check for separator */
-            if ($field['html'] == '-' && $i > 0 && $data['fields'][$i - 1]['html'] != '-') {
-                $tplfield['line'] = '<hr>';
-            } /* double separator, ignore */ elseif ($field['html'] == '-') {
-            } /* sections */ elseif ($field['html'] == 'section') {
-                $tplfield['line'] = $this->getSectionControl($field, $mode);
-            } /* only full HTML */ elseif (isset($field['line'])) {
-                $tplfield['line'] = $field['line'];
-            } /* edit field */ else {
-                if ($field['attribute']->m_ownerInstance->getNumbering()) {
-                    $this->_addNumbering($field, $tplfield, $i);
-                }
-
-                /* does the field have a label? */
-                if ((isset($field['label']) && $field['label'] !== 'AF_NO_LABEL') || !isset($field['label'])) {
-                    if ($field['label'] == '') {
-                        $tplfield['label'] = '';
-                    } else {
-                        $tplfield['label'] = $field['label'];
-                    }
-                } else {
-                    $tplfield['label'] = 'AF_NO_LABEL';
-                }
-
-                // Make the attribute and node names available in the template.
-                $tplfield['attribute'] = $field['attribute']->fieldName();
-                $tplfield['node'] = $field['attribute']->m_ownerInstance->atkNodeUri();
-
-                /* html source */
-                $tplfield['widget'] = $field['html'];
-                $editsrc = $field['html'];
-
-                $tplfield['id'] = str_replace('.', '_', $node->atkNodeUri().'_'.$field['id']);
-
-                $tplfield['full'] = $editsrc;
-            }
-            $fields[] = $tplfield; // make field available in numeric array
-            $params[$field['name']] = $tplfield; // make field available in associative array
-            $attributes[$field['name']] = $tplfield; // make field available in associative array
-        }
         $ui = $this->getUi();
 
         $tabTpl = $this->_getTabTpl($node, $tabs, $mode, $record);
 
         if ($template) {
-            $innerform = $ui->render($template, array('fields' => $fields, 'attributes' => $attributes));
+            $innerform = $ui->render($template, ['fields' => $fields]);
         } else {
             if (Tools::count(array_unique($tabTpl)) > 1) {
                 $tabForm = $this->_renderTabs($fields, $tabTpl);
                 $innerform = implode(null, $tabForm);
             } else {
-                $innerform = $ui->render($node->getTemplate('view', $record, $tab), array('fields' => $fields, 'attributes' => $attributes));
+                $innerform = $ui->render($node->getTemplate('view', $record, $tab), ['fields' => $fields]);
             }
         }
 
-        return $innerform;
+        return $this->tabulate('view', $fields, $innerform);
     }
 }

--- a/src/Handlers/ViewHandler.php
+++ b/src/Handlers/ViewHandler.php
@@ -84,7 +84,7 @@ class ViewHandler extends ViewEditBase
 
         if (is_object($ui)) {
             $params = $node->getDefaultActionParams();
-            $tab = $node->getActiveTab();
+            $tab = $node->getActiveTab('view');
             $innerform = $this->viewForm($record, 'view');
 
             $params['activeTab'] = $tab;

--- a/src/Handlers/ViewHandler.php
+++ b/src/Handlers/ViewHandler.php
@@ -154,6 +154,7 @@ class ViewHandler extends ViewEditBase
         $data = $node->viewArray($mode, $record);
 
         $fields = $this->fieldsWithTabsAndSections($data['fields']);
+        $tabHeader = $this->tabulate('view', $fields);
         // get active tab
         $tab = $this->getActiveTab();
         // get all tabs of current mode
@@ -164,16 +165,12 @@ class ViewHandler extends ViewEditBase
         $tabTpl = $this->_getTabTpl($node, $tabs, $mode, $record);
 
         if ($template) {
-            $innerform = $ui->render($template, ['fields' => $fields]);
-        } else {
-            if (Tools::count(array_unique($tabTpl)) > 1) {
-                $tabForm = $this->_renderTabs($fields, $tabTpl);
-                $innerform = implode(null, $tabForm);
-            } else {
-                $innerform = $ui->render($node->getTemplate('view', $record, $tab), ['fields' => $fields]);
-            }
+            return $tabHeader.$ui->render($template, ['fields' => $fields]);
         }
-
-        return $this->tabulate('view', $fields, $innerform);
+        if (Tools::count(array_unique($tabTpl)) > 1) {
+            $tabForm = $this->_renderTabs($fields, $tabTpl);
+            return $tabHeader.implode(null, $tabForm);
+        }
+        return $tabHeader.$ui->render($node->getTemplate('view', $record, $tab), ['fields' => $fields]);
     }
 }

--- a/src/Handlers/ViewHandler.php
+++ b/src/Handlers/ViewHandler.php
@@ -243,9 +243,6 @@ class ViewHandler extends ViewEditBase
                 $tplfield['id'] = str_replace('.', '_', $node->atkNodeUri().'_'.$field['id']);
 
                 $tplfield['full'] = $editsrc;
-
-                $column = $field['attribute']->getColumn();
-                $tplfield['column'] = $column;
             }
             $fields[] = $tplfield; // make field available in numeric array
             $params[$field['name']] = $tplfield; // make field available in associative array

--- a/src/RecordList/ColumnConfig.php
+++ b/src/RecordList/ColumnConfig.php
@@ -145,10 +145,8 @@ class ColumnConfig
      */
     public function init()
     {
-        foreach (array_keys($this->m_node->m_attribIndexList) as $i) {
-            if (isset($this->m_node->m_attribIndexList[$i]['name']) && ($this->m_node->m_attribIndexList[$i]['name'] != '')) {
-                $this->m_colcfg[$this->m_node->m_attribIndexList[$i]['name']] = [];
-            }
+        foreach (array_keys($this->m_node->getAttributes()) as $attribname) {
+            $this->m_colcfg[$attribname] = [];
         }
 
         if ($this->m_node->getOrder() != '') {

--- a/src/Relations/OneToOneRelation.php
+++ b/src/Relations/OneToOneRelation.php
@@ -671,7 +671,9 @@ class OneToOneRelation extends Relation
                     }
                 }
 
+
                 $a = $this->m_destInstance->editArray($mode, $myrecord, $forceList, [], $fieldprefix.$this->fieldName().'_AE_', false, false);
+                $entry = $this->sectionTabClassArray();
 
                 /* hidden fields */
                 $arr['hide'] = array_merge($arr['hide'], $a['hide']);
@@ -686,25 +688,30 @@ class OneToOneRelation extends Relation
                 if (!$this->hasFlag(self::AF_ONETOONE_INTEGRATE) && !$this->hasFlag(self::AF_NOLABEL) && !(Tools::count($a['fields']) == 1 && $a['fields'][0]['name'] == $this->m_name)) {
                     /* separator and name */
                     if ($arr['fields'][Tools::count($arr['fields']) - 1]['html'] !== '-') {
-                        $arr['fields'][] = array(
+                        $arr['fields'][] = [
                             'html' => '-',
-                            'tabs' => $this->m_tabs,
-                            'sections' => $this->getSections(),
-                        );
+                            'line' => '<hr/>',
+                            'class' => $entry['class'],
+                            'tabs' => $entry['tabs'],
+                            'section' => $entry['section'],
+                        ];
                     }
-                    $arr['fields'][] = array(
+
+                    $arr['fields'][] = [
                         'line' => '<b>'.Tools::atktext($this->m_name, $this->m_ownerInstance->m_module, $this->m_ownerInstance->m_type).'</b>',
-                        'tabs' => $this->m_tabs,
-                        'sections' => $this->getSections(),
-                    );
+                        'class' => $entry['class'],
+                        'tabs' => $entry['tabs'],
+                        'section' => $entry['section'],
+                    ];
                 }
 
                 if (is_array($a['fields'])) {
                     // in non-integration mode we move all the fields to the one-to-one relations tabs/sections
                     if (!$this->hasFlag(self::AF_ONETOONE_INTEGRATE) || $this->hasFlag(self::AF_ONETOONE_RESPECT_TABS)) {
                         foreach (array_keys($a['fields']) as $key) {
-                            $a['fields'][$key]['tabs'] = $this->m_tabs;
-                            $a['fields'][$key]['sections'] = $this->getSections();
+                            $a['fields'][$key]['tabs'] = $entry['tabs'];
+                            $a['fields'][$key]['section'] = $entry['section'];
+                            $a['fields'][$key]['class'] .= ' '.$entry['class'];
                         }
                     }
 
@@ -713,16 +720,13 @@ class OneToOneRelation extends Relation
 
                 if (!$this->hasFlag(self::AF_ONETOONE_INTEGRATE) && !$this->hasFlag(self::AF_NOLABEL) && !(Tools::count($a['fields']) == 1 && $a['fields'][0]['name'] == $this->m_name)) {
                     /* separator */
-                    $arr['fields'][] = array(
+                    $arr['fields'][] = [
                         'html' => '-',
-                        'tabs' => $this->m_tabs,
-                        'sections' => $this->getSections(),
-                    );
-                }
-
-                $fields = $arr['fields'];
-                foreach ($fields as &$field) {
-                    $field['attribute'] = '';
+                        'line' => '<hr/>',
+                        'class' => $entry['class'],
+                        'tabs' => $entry['tabs'],
+                        'section' => $entry['section'],
+                    ];
                 }
             }
         }
@@ -758,6 +762,7 @@ class OneToOneRelation extends Relation
 
             $record = $defaults[$this->fieldName()];
             $a = $this->m_destInstance->viewArray($mode, $record, false);
+            $entry = $this->sectionTabClassArray();
 
             /* editable fields, if self::AF_NOLABEL is specified or if there is just 1 field with the
              * same name as the relation we don't display a label
@@ -769,24 +774,29 @@ class OneToOneRelation extends Relation
             if (!$this->hasFlag(self::AF_ONETOONE_INTEGRATE) && !$this->hasFlag(self::AF_NOLABEL) && !(Tools::count($a['fields']) == 1 && $a['fields'][0]['name'] == $this->m_name)) {
                 /* separator and name */
                 if ($arr['fields'][Tools::count($arr['fields']) - 1]['html'] !== '-') {
-                    $arr['fields'][] = array(
+                    $arr['fields'][] = [
                         'html' => '-',
-                        'tabs' => $this->m_tabs,
-                        'sections' => $this->getSections(),
-                    );
+                        'line' => '<hr/>',
+                        'class' => $entry['class'],
+                        'tabs' => $entry['tabs'],
+                        'section' => $entry['section'],
+
+                    ];
                 }
-                $arr['fields'][] = array(
+                $arr['fields'][] = [
                     'line' => '<b>'.Tools::atktext($this->m_name, $this->m_ownerInstance->m_module, $this->m_ownerInstance->m_type).'</b>',
-                    'tabs' => $this->m_tabs,
-                    'sections' => $this->getSections(),
-                );
+                    'class' => $entry['class'],
+                    'tabs' => $entry['tabs'],
+                    'section' => $entry['section'],
+                ];
             }
 
             if (is_array($a['fields'])) {
                 if (!$this->hasFlag(self::AF_ONETOONE_INTEGRATE) || $this->hasFlag(self::AF_ONETOONE_RESPECT_TABS)) {
                     foreach (array_keys($a['fields']) as $key) {
-                        $a['fields'][$key]['tabs'] = $this->m_tabs;
-                        $a['fields'][$key]['sections'] = $this->getSections();
+                        $a['fields'][$key]['tabs'] = $entry['tabs'];
+                        $a['fields'][$key]['section'] = $entry['section'];
+                        $a['fields'][$key]['class'] .= ' '.$entry['class'];
                     }
                 }
                 $arr['fields'] = array_merge($arr['fields'], $a['fields']);
@@ -794,7 +804,12 @@ class OneToOneRelation extends Relation
 
             if (!$this->hasFlag(self::AF_ONETOONE_INTEGRATE) && !$this->hasFlag(self::AF_NOLABEL) && !(Tools::count($a['fields']) == 1 && $a['fields'][0]['name'] == $this->m_name)) {
                 /* separator */
-                $arr['fields'][] = array('html' => '-', 'tabs' => $this->m_tabs, 'sections' => $this->getSections());
+                $arr['fields'][] = [
+                        'line' => '<hr/>',
+                        'class' => $entry['class'],
+                        'tabs' => $entry['tabs'],
+                        'section' => $entry['section'],
+                ];
             }
         }
     }
@@ -863,35 +878,6 @@ class OneToOneRelation extends Relation
         } else {
             return $filter;
         }
-    }
-
-    /**
-     * Get list of additional tabs.
-     *
-     * Attributes can add new tabs to tabbed screens. This method will be
-     * called to retrieve the tabs. When self::AF_ONETOONE_INTEGRATE is set, the
-     * atkOneToOneRelation adds tabs from the destination node to the tab
-     * screen, so the attributes are seamlessly integrated but still on their
-     * own tabs.
-     *
-     * @param string $action The action for which additional tabs should be loaded.
-     *
-     * @return array The list of tabs to add to the screen.
-     */
-    public function getAdditionalTabs($action = null)
-    {
-        if ($this->hasFlag(self::AF_ONETOONE_INTEGRATE) && $this->createDestination()) {
-            $detailtabs = $this->m_destInstance->getTabs($action);
-            if (Tools::count($detailtabs) == 1 && $detailtabs[0] == 'default') {
-                // All elements in the relation are on the default tab. That means we should
-                // inherit the tab from the onetoonerelation itself.
-                return parent::getAdditionalTabs($action);
-            }
-
-            return $detailtabs;
-        }
-
-        return parent::getAdditionalTabs($action);
     }
 
     /**

--- a/src/Resources/public/javascript/tabs.js
+++ b/src/Resources/public/javascript/tabs.js
@@ -27,25 +27,25 @@ ATK.Tabs = {
         $('div.section-item').filter(function (id, tr) {
             return $(tr).hasClass(element.id);
         }).each(function (id, tr) {
-            var $tr = $(tr);
             if (expand) {
-                $tr.show();
-                $tr.removeClass('closedSection');
-                $tr.addClass('openedSection');
-                ATK.Tabs.closedSections = ATK.Tabs.closedSections.filter(id => id != element.id);
+                $(tr).show();
             } else {
-                $tr.hide();
-                $tr.removeClass('openedSection');
-                $tr.addClass('closedSection');
-                ATK.Tabs.closedSections.push(element.id);
+                $(tr).hide();
             }
         });
 
         var param;
+        icon = $("img_"+element.id);
         if (expand) {
             param = 'opened';
+            icon.removeClass('fa-plus-square-o');
+            icon.addClass('fa-minus-square-o');
+            ATK.Tabs.closedSections = ATK.Tabs.closedSections.filter(id => id != element.id);
         } else {
             param = 'closed';
+            icon.removeClass('fa-minus-square-o');
+            icon.addClass('fa-plus-square-o');
+            ATK.Tabs.closedSections.push(element.id);
         }
 
         $.get(url+'&atksectionstate='+param);

--- a/src/Resources/public/javascript/tabs.js
+++ b/src/Resources/public/javascript/tabs.js
@@ -35,7 +35,7 @@ ATK.Tabs = {
         });
 
         var param;
-        icon = $("img_"+element.id);
+        icon = $(document.getElementById("img_"+element.id));
         if (expand) {
             param = 'opened';
             icon.removeClass('fa-plus-square-o');

--- a/src/Resources/public/javascript/tabs.js
+++ b/src/Resources/public/javascript/tabs.js
@@ -4,6 +4,8 @@ if (!window.ATK) {
 
 ATK.Tabs = {
     closedSections: [],
+    tabs : [],
+    tabstateUrl: '',
 
     /**
      * Register an initially closed section.
@@ -54,24 +56,11 @@ ATK.Tabs = {
     /**
      * Sets the current tab
      */
-
     showTab: function (tab) {
-        // If we are called without a name, we check if the parent has a stored tab for our page
-        // If so, then we go there, else we go to the first tab (most of the time the 'default' tab)
+        // If we are called without a name, we go to the first tab (most of the time the 'default' tab)
         if (!tab) {
-            tab = ATK.Tabs.getCurrentTab();
-            if (tab) {
-                // However if for some reason this tab does not exist, we switch to the default tab
-                if (!document.getElementById('tab_' + tab))
-                    tab = tabs[0];
-            }
-            else {
-                tab = tabs[0];
-            }
+            tab = ATK.Tabs.tabs[0];
         }
-
-        // Then we store what tab we are going to visit in the parent
-        ATK.Tabs.setCurrentTab(tab);
 
         var sectionItems = jQuery('div.section-item');
         sectionItems.each(function (index, el) {
@@ -91,7 +80,7 @@ ATK.Tabs = {
             }
         });
 
-        jQuery(tabs).each(function (index, label) {
+        jQuery(ATK.Tabs.tabs).each(function (index, label) {
             var $tab = $(document.getElementById('tab_' + label));
             if (label === tab) {
                 $tab.addClass('activetab active').removeClass('passivetab');
@@ -99,57 +88,7 @@ ATK.Tabs = {
                 $tab.removeClass('activetab active').addClass('passivetab');
             }
         });
-    },
 
-    getCurrentTab: function () {
-        var getUriParams = function (name) {
-            return decodeURIComponent((new RegExp('[?|&]' + name + '=' + '([^&;]+?)(&|#|;|$)').exec(location.search) || [, ""])[1].replace(/\+/g, '%20')) || null;
-        };
-        if (getUriParams('stateful') == '1') {
-            return 'ATK.Tabs.getTab(ATK.Tools.getCurrentNodetype(), ATK.Tools.getCurrentSelector())';
-        }
-        return '';
-    },
-
-    getTab: function (nodetype, selector) {
-        ATK.Tabs.initTabArray(nodetype, selector);
-        return parent.document.tab[nodetype][selector];
-    },
-
-    setCurrentTab: function (value) {
-        ATK.Tabs.setTab(ATK.Tools.getCurrentNodetype(), ATK.Tools.getCurrentSelector(), value);
-
-        for (var i = 0; i < document.forms.length; i++) {
-            var form = document.forms[i];
-            if (form.atktab != null) {
-                form.atktab.value = value;
-                form.atktab.defaultValue = value;
-            } else {
-                var input = document.createElement('input');
-                input.setAttribute('type', 'hidden');
-                input.setAttribute('name', 'atktab');
-                input.setAttribute('value', value);
-                input.defaultValue = value;
-                form.appendChild(input);
-            }
-        }
-    },
-
-    setTab: function (nodetype, selector, value) {
-        ATK.Tabs.initTabArray(nodetype, selector);
-        parent.document.tab[nodetype][selector] = value;
-    },
-
-    /**
-     * Makes sure we don't get any nasty JS errors by making sure
-     * the arrays we use are always set before using them.
-     */
-    initTabArray: function (nodetype, selector) {
-        if (!parent.document.tab) {
-            parent.document.tab = [];
-        }
-        if (!parent.document.tab[nodetype]) {
-            parent.document.tab[nodetype] = [];
-        }
+        $.get(ATK.Tabs.tabstateUrl + tab);
     }
 };

--- a/src/Resources/public/javascript/tabs.js
+++ b/src/Resources/public/javascript/tabs.js
@@ -65,7 +65,7 @@ ATK.Tabs = {
         var sectionItems = jQuery('div.section-item');
         sectionItems.each(function (index, el) {
             var $el = jQuery(el);
-            var show = $el.attr('class').includes('section_'+tab);
+            var show = $el.attr('class').includes('section_'+tab) || $el.attr('class').includes('alltabs');
             ATK.Tabs.closedSections.forEach(function(section) {
                 if ($el.hasClass(section)) {
                     show = false;

--- a/src/Resources/public/javascript/tabs.js
+++ b/src/Resources/public/javascript/tabs.js
@@ -92,7 +92,7 @@ ATK.Tabs = {
         });
 
         jQuery(tabs).each(function (index, label) {
-            var $tab = jQuery('#tab_' + label);
+            var $tab = $(document.getElementById('tab_' + label));
             if (label === tab) {
                 $tab.addClass('activetab active').removeClass('passivetab');
             } else {

--- a/src/Resources/public/javascript/tabs.js
+++ b/src/Resources/public/javascript/tabs.js
@@ -18,26 +18,25 @@ ATK.Tabs = {
      * Toggle section visibility.
      */
     handleSectionToggle: function (element, expand, url) {
-        element = $(element);
-
 
         // automatically determine if we need to expand or collapse
         if (expand == null) {
             expand = ATK.Tabs.closedSections.indexOf(element.id) >= 0;
         }
 
-        $$('tr', 'div.atkSection', 'div.section-item').select(function (tr) {
-            return $(tr).hasClassName(element.id);
-        }).each(function (tr) {
+        $('div.section-item').filter(function (id, tr) {
+            return $(tr).hasClass(element.id);
+        }).each(function (id, tr) {
+            var $tr = $(tr);
             if (expand) {
-                Element.show(tr);
-                element.removeClassName('closedSection');
-                element.addClassName('openedSection');
-                ATK.Tabs.closedSections = ATK.Tabs.closedSections.without(element.id);
+                $tr.show();
+                $tr.removeClass('closedSection');
+                $tr.addClass('openedSection');
+                ATK.Tabs.closedSections = ATK.Tabs.closedSections.filter(id => id != element.id);
             } else {
-                Element.hide(tr);
-                element.removeClassName('openedSection');
-                element.addClassName('closedSection');
+                $tr.hide();
+                $tr.removeClass('openedSection');
+                $tr.addClass('closedSection');
                 ATK.Tabs.closedSections.push(element.id);
             }
         });
@@ -49,10 +48,7 @@ ATK.Tabs = {
             param = 'closed';
         }
 
-        new Ajax.Request(url, {
-            method: 'get',
-            parameters: 'atksectionstate=' + param
-        });
+        $.get(url+'&atksectionstate='+param);
     },
 
     /**
@@ -80,7 +76,12 @@ ATK.Tabs = {
         var sectionItems = jQuery('div.section-item');
         sectionItems.each(function (index, el) {
             var $el = jQuery(el);
-            var show = ($el.hasClass('section_' + tab) && ATK.Tabs.closedSections.indexOf($el.attr('id')) < 0);
+            var show = $el.attr('class').includes('section_'+tab);
+            ATK.Tabs.closedSections.forEach(function(section) {
+                if ($el.hasClass(section)) {
+                    show = false;
+                }
+            });
 
             if (show) {
                 $el.show();

--- a/src/Resources/public/javascript/tools.js
+++ b/src/Resources/public/javascript/tools.js
@@ -92,41 +92,6 @@ ATK.Tools = {
         return (replaced + haystack);
     },
 
-    /**
-     * Gets the atkselector of the current node
-     */
-    getCurrentSelector: function () {
-        var selectorobj = ATK.Tools.get_object("atkselector");
-        var selector;
-        if (selectorobj) {
-            if (selectorobj.value) {
-                selector = selectorobj.value;
-            }
-            else if (selectorobj.innerHTML) {
-                selector = selectorobj.innerHTML;
-            }
-        }
-        return selector;
-    },
-
-    /**
-     * Gets the atknodetype of the current node
-     */
-    getCurrentNodetype: function () {
-        var nodetypeobj = ATK.Tools.get_object("atknodeuri");
-        var nodetype;
-        if (nodetypeobj) {
-            // IE works with .value, while the Gecko engine uses .innerHTML
-            if (nodetypeobj.value) {
-                nodetype = nodetypeobj.value;
-            }
-            else if (nodetypeobj.innerHTML) {
-                nodetype = nodetypeobj.innerHTML;
-            }
-        }
-        return nodetype;
-    },
-
     hideAttrib: function (attrib) {
         var el = document.getElementById('ar_' + attrib);
         el.style.display = "none";

--- a/src/Resources/public/styles/style.css
+++ b/src/Resources/public/styles/style.css
@@ -3574,7 +3574,8 @@ tbody.collapse.in {
     max-width: none; }
 
 .nav-tabs {
-  border-bottom: 1px solid #ddd; }
+  border-bottom: 1px solid #ddd;
+  margin-bottom: 10px; }
   .nav-tabs > li {
     float: left;
     margin-bottom: -1px; }
@@ -9580,9 +9581,6 @@ ul {
 
 .input-group-addon {
   min-width: 25px; }
-
-.tabsContent {
-  margin-top: 10px; }
 
 @media (min-width: 768px) {
   .min-width_50 {

--- a/src/Resources/public/styles/style.css
+++ b/src/Resources/public/styles/style.css
@@ -9382,16 +9382,10 @@ A.atksection {
   background-position: 2px 5px;
   background-repeat: no-repeat;
   padding: 2px;
-  padding-left: 16px;
+  padding-left: 4px;
   width: 1px;
   white-space: nowrap;
   color: #000; }
-
-A.openedSection {
-  background-image: url("../images/minus.gif"); }
-
-A.closedSection {
-  background-image: url("../images/plus.gif"); }
 
 .ShuttleRelation .shuttle-controls {
   vertical-align: middle; }

--- a/src/Resources/src/sass/_sections.scss
+++ b/src/Resources/src/sass/_sections.scss
@@ -9,16 +9,8 @@ A.atksection {
     background-position: 2px 5px;
     background-repeat: no-repeat;
     padding: 2px;
-    padding-left: 16px;
+    padding-left: 4px;
     width: 1px;
     white-space: nowrap;
     color: #000;
-}
-
-A.openedSection {
-    background-image: url('../images/minus.gif');
-}
-
-A.closedSection {
-    background-image: url('../images/plus.gif');
 }

--- a/src/Resources/src/sass/_styles.scss
+++ b/src/Resources/src/sass/_styles.scss
@@ -16,7 +16,6 @@
 @import "sections";
 @import "ShuttleRelation";
 @import "stuff";
-@import "tabs";
 @import "widths";
 @import "select";
 @import "print";

--- a/src/Resources/src/sass/_tabs.scss
+++ b/src/Resources/src/sass/_tabs.scss
@@ -1,3 +1,0 @@
-.tabsContent {
-    margin-top: 10px;
-}

--- a/src/Resources/templates/field.tpl
+++ b/src/Resources/templates/field.tpl
@@ -1,16 +1,16 @@
-<div{if $field.rowid != ""} id="{$field.rowid}"{/if}{if $field.initial_on_tab!='yes'} style="display: none"{/if}
-        class="row section-item form-group {$field.tab} {if isset($field.obligatory)}required{/if} {if isset($field.error)}has-error{/if}">
+<div{if $field.id != ""} id="ar_{$field.id}"{/if}{if !$field.initial_on_tab} style="display: none"{/if}
+        class="row section-item form-group {$field.class} {if $field.obligatory}required{/if} {if $field.error}has-error{/if}">
     {if isset($field.line) && $field.line!=""}
         {$field.line}
     {else}
 
         {if $field.label!=="AF_NO_LABEL"}
-            <label for="{$field.htmlid}" class="col-sm-2 control-label">
+            <label for="{$field.id}" class="col-sm-2 control-label">
                 {if $field.label!=""}{$field.label}{/if}
             </label>
         {/if}
-        <div class="{if $field.label!=="AF_NO_LABEL"}col-sm-10{else}col-sm-12{/if}" id="{$field.id}">
-            {$field.full}
+        <div class="{if $field.label!=="AF_NO_LABEL"}col-sm-10{else}col-sm-12{/if}" id="ac_{$field.id}">
+            {$field.html}
         </div>
     {/if}
 </div>

--- a/src/Resources/templates/layout.tpl
+++ b/src/Resources/templates/layout.tpl
@@ -13,7 +13,6 @@
 
 {if isset($body)}
     <body{if $extrabodyprops} {$extrabodyprops}{/if}>{$body}
-        <div id="hiddenvars" style="display: none">{if isset($hiddenvars)}{$hiddenvars}{/if}</div>
     </body>
 {/if}
 

--- a/src/Resources/templates/panetabs.tpl
+++ b/src/Resources/templates/panetabs.tpl
@@ -7,5 +7,5 @@
             </li>
         {/foreach}
     </ul>
-    <div class="tabsContent">{$content}</div>
+    {$content}
 </div>

--- a/src/Resources/templates/tabs.tpl
+++ b/src/Resources/templates/tabs.tpl
@@ -1,8 +1,10 @@
 <script language="JavaScript" type="text/javascript">
-    var tabs = [];
+    ATK.Tabs.tabs = [
     {section name=i loop=$tabs}
-    tabs[tabs.length] = "{$tabs[i].tab}";
+    "{$tabs[i].tab}",
     {/section}
+    ];
+    ATK.Tabs.tabstateUrl = "{$tabstateUrl}";
 </script>
 
 

--- a/src/Resources/templates/tabs.tpl
+++ b/src/Resources/templates/tabs.tpl
@@ -17,5 +17,4 @@
     {/section}
 </ul>
 
-<div class="tabsContent">{$content}</div>
 

--- a/src/Ui/IndexPage.php
+++ b/src/Ui/IndexPage.php
@@ -261,24 +261,6 @@ class IndexPage
             $secMgr = SecurityManager::getInstance();
             $secMgr->logAction($node->m_type, $node->m_action);
             $node->callHandler($node->m_action);
-            $id = '';
-
-            if (isset($node->m_postvars['atkselector']) && is_array($node->m_postvars['atkselector'])) {
-                $atkSelectorDecoded = [];
-
-                foreach ($node->m_postvars['atkselector'] as $rowIndex => $selector) {
-                    list(, $pk) = explode('=', $selector);
-                    $atkSelectorDecoded[] = $pk;
-                    $id = implode(',', $atkSelectorDecoded);
-                }
-            } else {
-                list(, $id) = explode('=', Tools::atkArrayNvl($node->m_postvars, 'atkselector', '='));
-            }
-
-            $page->register_hiddenvars(array(
-                'atknodeuri' => $node->m_module.'.'.$node->m_type,
-                'atkselector' => str_replace("'", '', $id),
-            ));
         } else {
             $page->addContent($this->accessDeniedPage($node->getType()));
         }

--- a/src/Ui/Page.php
+++ b/src/Ui/Page.php
@@ -89,13 +89,6 @@ class Page
      */
     public $m_content = '';
 
-    /*
-     * The hidden variables for the page
-     * @access private
-     * @var array
-     */
-    public $m_hiddenvars = [];
-
     /**
      * Page title.
      *
@@ -353,20 +346,6 @@ class Page
     public function getStyleCodes()
     {
         return $this->m_stylecode;
-    }
-
-    /**
-     * Register hidden variables. These will be accessible to javascript and DHTML functions/scripts
-     * but will not be shown to the user unless he/she has a very, very old browser
-     * that is not capable of rendering CSS.
-     *
-     * @param array $hiddenvars the hiddenvariables we want to register
-     */
-    public function register_hiddenvars($hiddenvars)
-    {
-        foreach ($hiddenvars as $hiddenvarname => $hiddenvarvalue) {
-            $this->m_hiddenvars[$hiddenvarname] = $hiddenvarvalue;
-        }
     }
 
     /**
@@ -634,7 +613,6 @@ class Page
             $layout['body'] = $this->m_content."\n";
         }
 
-        $layout['hiddenvars'] = $this->hiddenVars();
         $layout['atkversion'] = Atk::VERSION;
 
         return $ui->render('layout.tpl', $layout);
@@ -651,24 +629,6 @@ class Page
         $this->addStyles($result, true);
 
         return $result;
-    }
-
-    /**
-     * Here we render a hidden div in the page with hidden variables
-     * that we want to make accessible to client side scripts.
-     *
-     * @return string a hidden div with the selected ATK variabels
-     */
-    public function hiddenVars()
-    {
-        $res = '';
-        if ($this->m_hiddenvars) {
-            foreach ($this->m_hiddenvars as $hiddenvarname => $hiddenvarvalue) {
-                $res .= "\n <span id='$hiddenvarname'>$hiddenvarvalue</span>";
-            }
-        }
-
-        return $res;
     }
 
     /**

--- a/src/Utils/EditFormModifier.php
+++ b/src/Utils/EditFormModifier.php
@@ -206,7 +206,7 @@ class EditFormModifier
         $re = '/<script.*>(.*)<\/script>/iU';
 
         foreach ($editArray['fields'] as $field) {
-            $element = '#'.str_replace('.', '_', $this->getNode()->atkNodeUri().'_'.$field['id']);
+            $element = '#'.str_replace('.', '_', 'ac_'.$field['id']);
 
             $value = preg_replace($re, '', $field['html']);
             $value = str_replace("'", "\\'", $value);


### PR DESCRIPTION
Hello,

In short : This pull request adds tab persistence (like section persistence) and make code more simple to handle tab/section rendering.
It is built upon #46, which focus on the same functionality (but while #46 only fixes thing, this PR includes more fundamental changes).

Long version : 
- Tab persistence now works and is implemented per node, the same way section persistence is implemented (by a cookie ... it may be more logical to store this setting in session variable !). It is not persistent per record, as it used to be before (when it worked) : if you select 'tab1' in 'record 27', then go to 'record 14' and select 'tab2' and come back to 'record 27', it will open on 'tab2'. All code related to persistence (sections / tabs) now lives in Handlers\ViewEditBase class and nothing remains in Node about it. It allowed to remove 'atkHiddenVars' stuff and related code, which was used only for tab persistence, a functionality that was broken.
- I've made more clear the handling of section/tabs stuff, and made explicit the fact that the field can be in a tab, in several tabs, in all tabs, in one section but **not** in several sections (before this PR, a field in several sections would be repeated in several places in the page and unspecified behaviour would happen).
- Section and/or tabs (we designate both terms as "form parts") are now only stored in the Attribute class, not in the Node class. The full list of tabs/sections is computed at the rendering time (function fieldsWithTabsAndSections in ViewEditBase class). These 2 changes allow to use $attr->setTabs or setSections *after* the attribute was added to the node (previously, it was mandatory to introduce sections or tabs with the node->add function for them to appear in the final form). As a consequence, Node->setTabIndex does not work anymore, but i've created Node->setTabOrder if you want a specific order for tabs (if not specified, tabs are listed in the order of the attributes they are in). Attribute->setSections is marked as deprecated, in favor of Attribute->setSection (one section), setTabs (one or several tabs) and setParts (section or tabs, depending on the value passed as parameter).
- These changes allowed to remove "broken functions" (as described by the comments surrounding them) in view/edit handlers and useless attributes given to templates (less code & lower memory footprint). There is also some factorization in ViewEditBase from ViewHandler/EditHandler.
- I've also cleaned up Node class : removed m_attribIndexList and replaced for loops by more logical foreach loops.

In the overall, this removes ~800 lines of code and adds functionality.


Note that this PR may not have security implications (except the fact that storing informations about navigation as browser cookies that could be kept after the session is closed may be considered as a security concern).