### PR TITLE
Remove hashed password from $_SESSION variable.

### DIFF
--- a/src/Security/Auth/DbAuth.php
+++ b/src/Security/Auth/DbAuth.php
@@ -198,7 +198,13 @@ class DbAuth extends AuthInterface
         if ($accountenableexpression) {
             $query->addCondition(" AND $accountenableexpression");
         }
-        return $query->executeSelect();
+	$recs = $query->executeSelect();
+        // Remove (hashed) password from columns (security reasons)
+        foreach (array_keys($recs) as $i) {
+            unset($recs[$i][Config::getGlobal('auth_passwordfield')]);
+        }
+
+        return $recs;
     }
 
     /**


### PR DESCRIPTION
Hello,

Investigating a bit the session behaviour, i discovered that all information about the account was stored in $_SESSION, including the password as stored in DB (i.e. hashed password by default).
This behavior makes hashed password for authenticated user written in the file system (not only in the DB), and thus could lead to sensitive data leakage (think backups, or flaw in a site that would allow attacker to read content of all sessions).

This very simple PR fixes that by removing the 'passwd' column of user information in DbAuth::getUser function.

Note that if you store other sensitive information in user table, it also appears in session files.