### PR TITLE
Fix deprecated syntax for string offset in SessionManager.php for branch 10.0 (and master)

### DIFF
--- a/src/Session/SessionManager.php
+++ b/src/Session/SessionManager.php
@@ -662,7 +662,7 @@ class SessionManager
 
                 // Posted vars always overwrite anything in the current session..
                 foreach (array_merge($pageVars, $sessionVars) as $var) {
-                    $recursive = $var{strlen($var) - 1} == '*';
+                    $recursive = $var[strlen($var) - 1] == '*';
                     $var = $recursive ? substr($var, 0, -1) : $var;
 
                     if (isset($postvars[$var]) && $postvars[$var] != '') {
@@ -688,7 +688,7 @@ class SessionManager
                 }
 
                 foreach ($pageVars as $var) {
-                    $recursive = $var{strlen($var) - 1} == '*';
+                    $recursive = $var[strlen($var) - 1] == '*';
                     $var = $recursive ? substr($var, 0, -1) : $var;
 
                     if (isset($postvars[$var]) && Tools::count($postvars[$var]) > 0 && (!$partial || !in_array($var, $lockedVars))) {


### PR DESCRIPTION
Using ATK with php7.4 / Debian stable yields following error :

> Deprecated: Array and string offset access syntax with curly braces is deprecated in vendor/sintattica/atk/src/Session/SessionManager.php on line 665
Deprecated: Array and string offset access syntax with curly braces is deprecated in vendor/sintattica/atk/src/Session/SessionManager.php on line 691

Switching `$var{strlen($var) - 1}` to `$var{strlen($var) - 1}` fixes the error.

I'm pushing against 10.0, but the same commit can be cherry-picked for master. For v9.2, same change was implemented by @NGjata in 26efcd39e74d72dfaba81a0423b5fc2087916d5a.